### PR TITLE
fix test, ensure searching in the right place

### DIFF
--- a/tests/134_minfo_and_optional_libs.phpt
+++ b/tests/134_minfo_and_optional_libs.phpt
@@ -22,7 +22,7 @@ ob_start();
 phpinfo(INFO_MODULES);
 $info = ob_get_clean();
 
-$section_start = strpos($info, 'fastchart');
+$section_start = strpos($info, 'fastchart support');
 $section = substr($info, $section_start, 800);
 
 echo "has_version_row: ",


### PR DESCRIPTION
Test failling because of found "fastchar" in 
`extension_dir => /tmp/fastchart/modules/ => /tmp/fastchart/modules/`
which is much more than 800 chars before extension part
