### PR TITLE
Fix undefined $ext_builddir

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -193,6 +193,11 @@ if test "$PHP_FASTCHART" != "no"; then
     FASTCHART_CFLAGS="$FASTCHART_CFLAGS -Werror -Wstrict-prototypes"
   fi
 
+  PHP_NEW_EXTENSION(fastchart,
+    $WRAPPER_SOURCES,
+    $ext_shared,,
+    $FASTCHART_CFLAGS)
+
   PHP_ADD_INCLUDE([$ext_srcdir])
   dnl Vendor include paths. Uses $abs_srcdir (autoconf-standard, always
   dnl populated before this macro fires) so VPATH / out-of-tree builds
@@ -208,9 +213,4 @@ if test "$PHP_FASTCHART" != "no"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/vendor/qrcodegen])
   PHP_ADD_BUILD_DIR([$ext_builddir/vendor/plutovg/source])
   PHP_ADD_BUILD_DIR([$ext_builddir/vendor/plutosvg/source])
-
-  PHP_NEW_EXTENSION(fastchart,
-    $WRAPPER_SOURCES,
-    $ext_shared,,
-    $FASTCHART_CFLAGS)
 fi


### PR DESCRIPTION
`$ext_builddir` is only defined after `PHP_NEW_EXTENSION`

Without this:

```
$ ../configure
...
Generating files
configure: creating build directories
mkdir: cannot create directory '/vendor': Permission denied
mkdir: cannot create directory '/vendor/qrcodegen': No such file or directory
mkdir: cannot create directory '/vendor': Permission denied
mkdir: cannot create directory '/vendor/plutovg': No such file or directory
mkdir: cannot create directory '/vendor/plutovg/source': No such file or directory
mkdir: cannot create directory '/vendor': Permission denied
mkdir: cannot create directory '/vendor/plutosvg': No such file or directory
mkdir: cannot create directory '/vendor/plutosvg/source': No such file or directory
configure: creating Makefile
```

Especially a problem for out of sources tree build