### PR TITLE
fix tests, more font paths for RPM dsitro

### DIFF
--- a/tests/089_font_cache_open_basedir.phpt
+++ b/tests/089_font_cache_open_basedir.phpt
@@ -12,6 +12,7 @@ $cands = [
     '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
     '/usr/share/fonts/dejavu/DejaVuSans.ttf',
     '/usr/share/fonts/TTF/DejaVuSans.ttf',
+    '/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf',
 ];
 $ok = false;
 foreach ($cands as $c) { if (file_exists($c)) { $ok = true; break; } }
@@ -34,6 +35,7 @@ $font_candidates = [
     '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
     '/usr/share/fonts/dejavu/DejaVuSans.ttf',
     '/usr/share/fonts/TTF/DejaVuSans.ttf',
+    '/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf',
 ];
 $font = null;
 foreach ($font_candidates as $cand) {

--- a/tests/129_svg_text_modes.phpt
+++ b/tests/129_svg_text_modes.phpt
@@ -12,6 +12,7 @@ $candidates = [
     '/usr/share/fonts/truetype/lato/Lato-Regular.ttf',
     '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
     '/usr/share/fonts/dejavu/DejaVuSans.ttf',
+    '/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf',
 ];
 $font = '';
 foreach ($candidates as $p) { if (is_readable($p)) { $font = $p; break; } }

--- a/tests/131_raster_formats_per_family.phpt
+++ b/tests/131_raster_formats_per_family.phpt
@@ -12,10 +12,16 @@ gd
  * instance of every chart family and asserts the four output
  * formats each produce magic-byte-correct bytes at non-trivial size. */
 
-$lato = '/usr/share/fonts/truetype/lato/Lato-Regular.ttf';
-$font = is_readable($lato) ? $lato
-        : '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf';
-if (!is_readable($font)) die("skip no system font available\n");
+// Pick a system font; fall back across distros.
+$candidates = [
+    '/usr/share/fonts/truetype/lato/Lato-Regular.ttf',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+    '/usr/share/fonts/dejavu/DejaVuSans.ttf',
+    '/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf',
+];
+$font = '';
+foreach ($candidates as $p) { if (is_readable($p)) { $font = $p; break; } }
+if ($font === '') die("skip no system font found\n");
 
 $ohlcv = [];
 for ($i = 0; $i < 8; $i++) {


### PR DESCRIPTION
quick fix

Perhaps better to use a helper with a single definition of the candidates
