### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4', '8.5']
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
         cc: ['gcc']
         # One clang lane: clang's diagnostics differ from gcc's and catch
         # warnings/UB the gcc matrix misses. It does NOT catch the
@@ -291,7 +291,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
         uses: php/php-windows-builder/extension-matrix@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 # v1
         with:
           extension-url: ${{ github.event.repository.html_url }}
-          php-version-list: '8.3, 8.4, 8.5'
+          php-version-list: '8.1, 8.2, 8.3, 8.4, 8.5'
 
   windows-build:
     name: Build ${{ matrix.php-version }} ${{ matrix.arch }} ${{ matrix.ts }}

--- a/.release-config
+++ b/.release-config
@@ -7,6 +7,8 @@ version_macro: PHP_FASTCHART_VERSION
 version_file: php_fastchart.h
 repo: iliaal/fastchart
 build_matrix:
+  - PHP-8.1
+  - PHP-8.2
   - PHP-8.3
   - PHP-8.4
   - PHP-8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PHP 8.1 support (lowered the minimum from 8.3).
+
 ## [1.1.6] - 2026-06-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ php -d extension=./modules/fastchart.so \
 
 ## Requirements
 
-- PHP 8.3 or later (NTS or ZTS).
+- PHP 8.1 or later (NTS or ZTS).
 - **FreeType** development headers (`libfreetype-dev` /
   `freetype-devel`). Required, since text rendering depends on FreeType.
 - **libpng / libjpeg-turbo / libwebp** development headers. Each is

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3"
+        "php": ">=8.1"
     },
     "php-ext": {
         "extension-name": "fastchart",

--- a/config.m4
+++ b/config.m4
@@ -20,8 +20,8 @@ PHP_ARG_WITH(fastchart-static-codecs, prefix containing static-built codec libs,
 if test "$PHP_FASTCHART" != "no"; then
 
   PHP_VERSION_ID=$($PHP_CONFIG --vernum)
-  if test "$PHP_VERSION_ID" -lt "80300"; then
-    AC_MSG_ERROR([fastchart requires PHP 8.3.0 or later (found $PHP_VERSION_ID)])
+  if test "$PHP_VERSION_ID" -lt "80100"; then
+    AC_MSG_ERROR([fastchart requires PHP 8.1.0 or later (found $PHP_VERSION_ID)])
   fi
 
   dnl ----- pkg-config-resolved deps ---------------------------------------

--- a/fastchart.c
+++ b/fastchart.c
@@ -6078,11 +6078,11 @@ ZEND_METHOD(FastChart_PolarChart, setSeries)
             (slot_)->angles = emalloc((size_t)_np * sizeof(double));     \
             (slot_)->radii  = emalloc((size_t)_np * sizeof(double));     \
             int _k = 0;                                                  \
-            zval *_p;                                                    \
-            ZEND_HASH_FOREACH_VAL(_dh, _p) {                             \
-                if (Z_TYPE_P(_p) != IS_ARRAY) continue;                  \
-                zval *_za = zend_hash_index_find(Z_ARRVAL_P(_p), 0);     \
-                zval *_zr = zend_hash_index_find(Z_ARRVAL_P(_p), 1);     \
+            zval *_pv;                                                    \
+            ZEND_HASH_FOREACH_VAL(_dh, _pv) {                             \
+                if (Z_TYPE_P(_pv) != IS_ARRAY) continue;                  \
+                zval *_za = zend_hash_index_find(Z_ARRVAL_P(_pv), 0);     \
+                zval *_zr = zend_hash_index_find(Z_ARRVAL_P(_pv), 1);     \
                 if (!_za || !_zr) continue;                              \
                 double _a, _r;                                           \
                 if (fastchart_zval_to_double(_za, &_a) != 0) continue;   \

--- a/php_fastchart.h
+++ b/php_fastchart.h
@@ -92,6 +92,20 @@ static inline zend_class_entry *zend_register_internal_class_with_flags(
 }
 #endif
 
+/* PHP 8.2 compat shim for zend_declare_typed_class_constant (added in
+ * 8.3). gen_stub.php emits it for any typed class constant (the stub's
+ * `public const int FOO = N;` enums). 8.2 has no typed class constants,
+ * so register an untyped one with the same value and drop the type. */
+#if PHP_VERSION_ID < 80300
+static zend_always_inline zend_class_constant *zend_declare_typed_class_constant(
+    zend_class_entry *ce, zend_string *name, zval *value,
+    int flags, zend_string *doc_comment, zend_type type)
+{
+    (void) type;
+    return zend_declare_class_constant_ex(ce, name, value, flags, doc_comment);
+}
+#endif
+
 extern zend_class_entry *fastchart_chart_ce;
 extern zend_class_entry *fastchart_line_chart_ce;
 extern zend_class_entry *fastchart_area_chart_ce;

--- a/tests/152_round5_audit_fixes.phpt
+++ b/tests/152_round5_audit_fixes.phpt
@@ -125,14 +125,19 @@ $disk = file_get_contents($tmp_jpg);
 echo "chart_renderToFile_uses_jpegQuality: ",
     (abs(strlen($ram) - strlen($disk)) < 50 ? "ok" : "fail"), "\n";
 
-/* Explicit quality argument still works and overrides the setter. */
+/* Explicit quality argument still works and overrides the setter.
+ * clearstatcache() before every filesize() read: PHP 8.2 does not
+ * invalidate the stat cache when renderToFile() overwrites a path, so a
+ * stale size from the previous write would leak in (8.3+ auto-clears). */
 $c->renderToFile($tmp_jpg, 90);
+clearstatcache();
 $disk_q90 = filesize($tmp_jpg);
 echo "chart_explicit_quality_wins: ",
     ($disk_q90 > strlen($disk) * 2 ? "ok" : "fail"), "\n";
 
 /* Explicit quality argument that matches setter produces same output. */
 $c->renderToFile($tmp_jpg, 1);
+clearstatcache();
 echo "chart_explicit_quality_1: ",
     (abs(filesize($tmp_jpg) - strlen($ram)) < 50 ? "ok" : "fail"), "\n";
 
@@ -156,11 +161,13 @@ $q = (new FastChart\QrCode(200, 200))
     ->setJpegQuality(1);
 $ram_q = $q->renderJpeg();
 $q->renderToFile($tmp_jpg);
+clearstatcache();
 echo "symbol_renderToFile_uses_jpegQuality: ",
     (abs(strlen($ram_q) - filesize($tmp_jpg)) < 50 ? "ok" : "fail"), "\n";
 
 /* Symbol explicit quality wins. */
 $q->renderToFile($tmp_jpg, 90);
+clearstatcache();
 echo "symbol_explicit_quality_wins: ",
     (filesize($tmp_jpg) > strlen($ram_q) * 2 ? "ok" : "fail"), "\n";
 


### PR DESCRIPTION
Lowers the minimum from 8.3 to 8.1 (so 8.1 and 8.2 are both newly supported).

**Two small compat shims close the gap to older PHP:**
- `zend_declare_typed_class_constant` (8.3+) — gen_stub emits it for the stub's typed `const int` enums; shimmed to the untyped registration on `< 8.3` (value preserved; older PHP has no typed class constants to introspect).
- `POLAR_PARSE_DATA` loop variable renamed off `_p` — 8.1's `ZEND_HASH_FOREACH_VAL` declares an internal `Bucket *_p` that shadows the macro's `zval *_p` (8.2+ removed that internal). Harmless on every version; also removes a latent shadowing fragility.

**Everything else is declarative:** floors in `config.m4` / `composer.json` / `README`, and 8.1 + 8.2 joining the test and Windows build matrices. Prebuilt Linux/macOS lanes stay 8.4/8.5; older versions source-build via PIE.

**One test fix.** `152_round5_audit_fixes` read `filesize()` after `renderToFile()` overwrote the same path. PHP 8.1/8.2 don't invalidate the stat cache on overwrite (8.3+ do), so the explicit-quality JPEG checks saw a stale size. `renderToFile` writes correct bytes via `php_stream` either way; `clearstatcache()` makes the test version-robust.

**Note:** PHP 8.1 is past end-of-life (security support ended 2025-12-31). Included because the marginal cost over 8.2 was one variable rename, but it is lower-value than 8.2.

**Verified** on php-src 8.1 and 8.2 ASAN builds (same libjpeg/freetype as 8.3/8.4/8.5): 143/143 each; 8.3/8.4 still 143/143 (rename is a no-op there).