### PR TITLE
add pdfio version in phpinfo

### DIFF
--- a/fastchart.c
+++ b/fastchart.c
@@ -35,6 +35,10 @@
 #include "fastchart_encoder.h"
 #include "fastchart_rasterize.h"
 
+#ifdef HAVE_FASTCHART_PDF
+#include <pdfio.h>
+#endif
+
 #include "plutovg.h"
 #include "plutosvg.h"
 
@@ -8673,6 +8677,7 @@ PHP_MINFO_FUNCTION(fastchart)
 
 #ifdef HAVE_FASTCHART_PDF
     php_info_print_table_row(2, "PDF output (pdfio)", "enabled");
+    php_info_print_table_row(2, "pdfio", PDFIO_VERSION);
 #else
     php_info_print_table_row(2, "PDF output (pdfio)", "(not compiled in)");
 #endif


### PR DESCRIPTION
Display pdfio version like for other libraries (may help for support)

```
$ php -n -d extension=modules/fastchart.so --ri fastchart

fastchart

fastchart support => enabled
fastchart version => 1.3.0
FreeType => 2.13.3
libpng => 1.6.58
libjpeg => 3.1.3 (turbo)
libwebp => 1.6.0
PDF output (pdfio) => enabled
pdfio => 1.6.4
plutovg => 1.3.3
plutosvg => 0.0.8
Default font => /usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf

```