### PR TITLE
ci: fold the arm64 lane into the linux matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,24 +188,47 @@ jobs:
           '
 
   linux:
-    name: PHP ${{ matrix.php }} (${{ matrix.cc }}) - Linux
-    runs-on: ubuntu-latest
+    name: PHP ${{ matrix.php }} (${{ matrix.cc }}) - Linux ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2', '8.3', '8.4', '8.5']
         cc: ['gcc']
-        # One clang lane: clang's diagnostics differ from gcc's and catch
-        # warnings/UB the gcc matrix misses. It does NOT catch the
-        # static/musl dlopen class on its own (a clang glibc build bundles
-        # the same symbols a gcc build does) — the symbol-audit step below
-        # and the musl-smoke job cover that.
+        os: ['ubuntu-latest']
+        # Both extra lanes must OVERWRITE an original matrix value to
+        # become new combinations. An include whose existing-dimension
+        # values all match a base combination gets its keys merged INTO
+        # that combination instead: `{php: 8.4, cc: gcc, os: <arm>}`
+        # against a matrix with no `os` dimension would move the x86
+        # 8.4-gcc lane to arm64 rather than adding one, silently dropping
+        # x86 coverage. Declaring `os` above is what keeps that honest.
         include:
+          # clang's diagnostics differ from gcc's and catch warnings/UB
+          # the gcc lanes miss. It does NOT catch the static/musl dlopen
+          # class on its own (a clang glibc build bundles the same
+          # symbols a gcc build does) — the symbol-audit step below and
+          # the musl-smoke job cover that.
           - php: '8.4'
             cc: 'clang'
+            os: 'ubuntu-latest'
+          # The gcc lanes above are x86_64, so they compile the SSSE3
+          # un-premultiply path and never the NEON one, and the only
+          # other arm64 runner in this file is macOS, which builds with
+          # clang and therefore has no -Wclobbered and none of gcc's
+          # other aarch64 diagnostics. release-linux.yml does build
+          # ubuntu-24.04-arm with the developer gate, but collapses to
+          # x86_64 on pull_request, so an aarch64-only break stayed
+          # invisible until a release was cut — which is how a
+          # -Werror=clobbered failure in fastchart_rasterize.c reached
+          # master.
+          - php: '8.4'
+            cc: 'gcc'
+            os: 'ubuntu-24.04-arm'
     env:
       MATRIX_CC: ${{ matrix.cc }}
       PHP_VERSION: ${{ matrix.php }}
+      RUNNER_LABEL: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -238,7 +261,7 @@ jobs:
           set +o pipefail
           WARNINGS=$(grep -c 'warning:' /tmp/build.log || true)
           if [ "$WARNINGS" -gt 0 ]; then
-            echo "::error::Build produced $WARNINGS warning(s) with ${MATRIX_CC}"
+            echo "::error::Build produced $WARNINGS warning(s) with ${MATRIX_CC} on ${RUNNER_LABEL}"
             exit 1
           fi
 
@@ -305,12 +328,12 @@ jobs:
           rc=${PIPESTATUS[0]}
           set -e
           if [ "$rc" -ne 0 ]; then
-            echo "::error::run-tests.php exited $rc on PHP ${PHP_VERSION} - Linux (crash / BORK / aborted before summary)"
+            echo "::error::run-tests.php exited $rc on PHP ${PHP_VERSION} - Linux ${RUNNER_LABEL} (crash / BORK / aborted before summary)"
             grep -E '^FAIL\b|^FAILED TEST|^BORK' /tmp/test-output.txt || true
             exit 1
           fi
           if grep -qP '^Tests failed\s*:\s*[1-9]' /tmp/test-output.txt; then
-            echo "::error::Tests failed on PHP ${PHP_VERSION} - Linux"
+            echo "::error::Tests failed on PHP ${PHP_VERSION} - Linux ${RUNNER_LABEL}"
             grep -E '^FAIL\b|^FAILED TEST' /tmp/test-output.txt || true
             exit 1
           fi
@@ -327,103 +350,7 @@ jobs:
           SKIPPED=${SKIPPED:-0}
           echo "Tests skipped: $SKIPPED (ceiling 25)"
           if [ "$SKIPPED" -gt 25 ]; then
-            echo "::error::Skip count $SKIPPED exceeds ceiling 25 on PHP ${PHP_VERSION} - Linux — a capability likely vanished (gd/webp/fonts); tests are hiding in the skip counter"
-            grep -E '^SKIP\b' /tmp/test-output.txt || true
-            exit 1
-          fi
-
-  linux-arm64:
-    # The gcc matrix above is x86_64 only, so it compiles the SSSE3
-    # un-premultiply path and never the NEON one. macos-latest is arm64
-    # but builds with clang, which has no -Wclobbered and none of gcc's
-    # other aarch64-specific diagnostics. release-linux.yml does build
-    # ubuntu-24.04-arm with --enable-fastchart-dev, but its matrix
-    # collapses to x86_64 on pull_request, so an aarch64-only build
-    # break stays invisible until a release is cut — which is how a
-    # -Werror=clobbered failure in fastchart_rasterize.c reached master.
-    # One lane at the current stable PHP is enough to close that gap.
-    name: PHP 8.4 (gcc) - Linux arm64
-    runs-on: ubuntu-24.04-arm
-    env:
-      PHP_VERSION: '8.4'
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            libfreetype-dev libpng-dev libjpeg-turbo8-dev libwebp-dev pkg-config
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # master
-        with:
-          php-version: '8.4'
-          extensions: gd
-          tools: phpize, php-config
-
-      - name: Build extension
-        run: |
-          phpize
-          ./configure --enable-fastchart --enable-fastchart-dev
-          set -o pipefail
-          make -j$(nproc) 2>&1 | tee /tmp/build.log
-          set +o pipefail
-          WARNINGS=$(grep -c 'warning:' /tmp/build.log || true)
-          if [ "$WARNINGS" -gt 0 ]; then
-            echo "::error::Build produced $WARNINGS warning(s) on arm64"
-            exit 1
-          fi
-
-      - name: Verify gd capabilities (guard against silent mass-skips)
-        run: |
-          php -r '
-            if (!extension_loaded("gd")) {
-              fwrite(STDERR, "gd not loaded — ~91 raster round-trip tests would skip silently\n");
-              exit(1);
-            }
-            $i = gd_info();
-            $need = ["WebP Support", "JPEG Support", "FreeType Support", "PNG Support"];
-            $missing = [];
-            foreach ($need as $k) { if (empty($i[$k])) { $missing[] = $k; } }
-            if ($missing) {
-              fwrite(STDERR, "gd is missing: " . implode(", ", $missing) .
-                " — raster round-trip tests would skip silently\n");
-              exit(1);
-            }
-            echo "gd capabilities OK: " . implode(", ", $need) . "\n";
-          '
-
-      - name: Run tests
-        run: |
-          export TEST_PHP_EXECUTABLE=$(which php)
-          export TEST_PHP_ARGS="-d extension=$(pwd)/modules/fastchart.so"
-          export NO_INTERACTION=1
-          set +e
-          php run-tests.php --show-diff -g FAIL,BORK,LEAK,XLEAK tests/ 2>&1 | tee /tmp/test-output.txt
-          rc=${PIPESTATUS[0]}
-          set -e
-          if [ "$rc" -ne 0 ]; then
-            echo "::error::run-tests.php exited $rc on PHP 8.4 - Linux arm64 (crash / BORK / aborted before summary)"
-            grep -E '^FAIL\b|^FAILED TEST|^BORK' /tmp/test-output.txt || true
-            exit 1
-          fi
-          if grep -qP '^Tests failed\s*:\s*[1-9]' /tmp/test-output.txt; then
-            echo "::error::Tests failed on PHP 8.4 - Linux arm64"
-            grep -E '^FAIL\b|^FAILED TEST' /tmp/test-output.txt || true
-            exit 1
-          fi
-          # Same budget as the x86_64 gcc lanes: gd is loaded and the
-          # build is PDF-less, so 7 PDF + up to 12 font-gated + locale +
-          # environment-gated skips, 25 with slack.
-          SKIPPED=$(grep -oP '^Tests skipped\s*:\s*\K[0-9]+' /tmp/test-output.txt | head -1)
-          SKIPPED=${SKIPPED:-0}
-          echo "Tests skipped: $SKIPPED (ceiling 25)"
-          if [ "$SKIPPED" -gt 25 ]; then
-            echo "::error::Skip count $SKIPPED exceeds ceiling 25 on PHP 8.4 - Linux arm64 — a capability likely vanished (gd/webp/fonts); tests are hiding in the skip counter"
+            echo "::error::Skip count $SKIPPED exceeds ceiling 25 on PHP ${PHP_VERSION} - Linux ${RUNNER_LABEL} — a capability likely vanished (gd/webp/fonts); tests are hiding in the skip counter"
             grep -E '^SKIP\b' /tmp/test-output.txt || true
             exit 1
           fi

--- a/fastchart_rasterize.c
+++ b/fastchart_rasterize.c
@@ -39,6 +39,23 @@ static size_t fastchart_image_cache_limit(void)
 	return FC_IMAGE_CACHE_MAX_BYTES;
 }
 
+/* Sole entry point for parsing caller SVG. The image-cache ceiling is
+ * applied here so a new parse site cannot leave the document on the
+ * vendor default. Returns NULL when the document does not parse or
+ * exceeds the parser's complexity limits. */
+static plutosvg_document_t *fastchart_load_svg(const char *svg,
+                                                size_t svg_len)
+{
+	plutosvg_document_t *doc =
+	    plutosvg_document_load_from_data(svg, (int)svg_len, -1, -1,
+	                                     NULL, NULL);
+	if (doc) {
+		plutosvg_document_set_image_cache_limit(doc,
+			fastchart_image_cache_limit());
+	}
+	return doc;
+}
+
 /* x86 SSSE3 worker fns carry __attribute__((target("ssse3"))); runtime
  * dispatch detects the feature via raw CPUID (__get_cpuid from
  * <cpuid.h>), NOT __builtin_cpu_supports. The builtin pulls in libgcc's
@@ -326,16 +343,12 @@ int fastchart_rasterize_svg(const char *svg, size_t svg_len,
 	 * contract for the vendor-state window. */
 	pix->rgba = safe_emalloc((size_t)target_w * (size_t)target_h, 4, 0);
 
-	plutosvg_document_t *doc =
-	    plutosvg_document_load_from_data(svg, (int)svg_len, -1, -1,
-	                                     NULL, NULL);
+	plutosvg_document_t *doc = fastchart_load_svg(svg, svg_len);
 	if (!doc) {
 		efree(pix->rgba);
 		pix->rgba = NULL;
 		return -1;
 	}
-	plutosvg_document_set_image_cache_limit(doc,
-		fastchart_image_cache_limit());
 
 	int rc;
 	zend_try {
@@ -373,12 +386,8 @@ int fastchart_rasterize_svg_with_dims(const char *svg, size_t svg_len,
 	if (out_h) *out_h = 0;
 	if (svg_len > (size_t)INT_MAX) return -2;
 
-	plutosvg_document_t *doc =
-	    plutosvg_document_load_from_data(svg, (int)svg_len, -1, -1,
-	                                     NULL, NULL);
+	plutosvg_document_t *doc = fastchart_load_svg(svg, svg_len);
 	if (!doc) return -1;
-	plutosvg_document_set_image_cache_limit(doc,
-		fastchart_image_cache_limit());
 
 	float w = plutosvg_document_get_width(doc);
 	float h = plutosvg_document_get_height(doc);

--- a/vendor/plutosvg/source/plutosvg.c
+++ b/vendor/plutosvg/source/plutosvg.c
@@ -2613,13 +2613,21 @@ static size_t image_cache_value(size_t remaining_uses, size_t bytes)
     return remaining_uses * bytes;
 }
 
-/* Make room for `bytes` by dropping cached surfaces that are worth less
- * than the incoming one, oldest first. Value is remaining_uses * bytes,
- * so a large image nobody references again goes before a small one the
- * document still uses many times.
+/* A cached surface may be dropped for an incoming one only if it is
+ * worth strictly less. Value is remaining_uses * bytes, so a large image
+ * nobody references again yields to a small one the document still uses
+ * many times. */
+static bool image_cache_evictable(const element_t* element,
+    size_t candidate_value)
+{
+    return image_cache_value(element->image_access_count,
+        element->image_cache_bytes) < candidate_value;
+}
+
+/* Make room for `bytes` by dropping evictable surfaces, oldest first.
  *
  * Two passes over the LRU list and no allocation: the first asks whether
- * the eligible entries even cover the shortfall, the second evicts. A
+ * the evictable entries even cover the shortfall, the second evicts. A
  * caller whose own value does not beat every entry it would displace
  * goes uncached rather than churning the cache. */
 static bool image_cache_reserve(plutosvg_document_t* document,
@@ -2638,10 +2646,8 @@ static bool image_cache_reserve(plutosvg_document_t* document,
     size_t freed = 0;
     for(const element_t* element = document->image_cache_head;
         element && freed < required; element = element->image_cache_next) {
-        if(image_cache_value(element->image_access_count,
-                element->image_cache_bytes) < candidate_value) {
+        if(image_cache_evictable(element, candidate_value))
             freed += element->image_cache_bytes;
-        }
     }
     if(freed < required)
         return false;
@@ -2650,8 +2656,7 @@ static bool image_cache_reserve(plutosvg_document_t* document,
     element_t* element = document->image_cache_head;
     while(element && freed < required) {
         element_t* next = element->image_cache_next;
-        if(image_cache_value(element->image_access_count,
-                element->image_cache_bytes) < candidate_value) {
+        if(image_cache_evictable(element, candidate_value)) {
             freed += element->image_cache_bytes;
             image_cache_unlink(document, element);
             document->image_cache_bytes -= element->image_cache_bytes;


### PR DESCRIPTION
Two changes on top of master, plus the reason this went through a PR
rather than straight to master.

## Fold the arm64 lane into the linux matrix

The arm64 job added earlier today duplicated the `linux` job almost
verbatim: same apt line, same build-and-count-warnings step, same gd
capability probe, same failure and skip-ceiling gates. Ninety-six lines
kept in step by hand. It is now one include entry.

The subtlety is why `os` is declared as a matrix dimension instead of
appearing only in the include. An include whose existing-dimension
values all match a base combination gets its keys merged **into** that
combination rather than creating a new one. With no `os` dimension,
`{php: 8.4, cc: gcc, os: ubuntu-24.04-arm}` would have moved the x86
8.4-gcc lane to arm64 instead of adding a lane, and the matrix would
have quietly tested less. Declaring `os` makes the arm entry overwrite
an original value, which is what forces a new combination.

That failure mode is silent, which is why this is a PR: the job list
below is the verification. Expect seven `linux` lanes, both an
`ubuntu-latest` and an `ubuntu-24.04-arm` entry at 8.4-gcc.

## Simplify two spots from the audit batch

`fastchart_load_svg()` folds the document parse and the image-cache
ceiling into one call. They were separate steps at both rasterize entry
points, so a third parse site would have compiled clean and silently run
on plutosvg's 64 MiB default, ignoring `fastchart.max_image_cache_bytes`.

`image_cache_evictable()` gives `image_cache_reserve()`'s feasibility
pass and eviction pass one predicate. They have to agree; drift would
let the first promise bytes the second never frees.

Net +14 lines. Neither is about volume.

## Verification

- 20/20 `review_perf` scenarios render byte-identical `output_sha256`
  against `9373326`
- x86 suite 358/360, 0 failures
- aarch64 `--enable-fastchart-dev` builds with 0 warnings, so the
  `-Wclobbered` function split survives the rasterize edit
