### PR TITLE
ci: bump php-windows-builder to 1.9.0 and dedupe the VS cache save

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
         # than v1, because upstream moves v1 forward and that desyncs
         # the pin from its comment, tripping zizmor ref-version-mismatch.
         # Bump via: gh api repos/php/php-windows-builder/tags
-        uses: php/php-windows-builder/extension-matrix@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 # 1.8.1
+        uses: php/php-windows-builder/extension-matrix@29352c0ef9e8ce65264ea9e287881a6f7758a953 # 1.9.0
         with:
           extension-url: ${{ github.event.repository.html_url }}
           php-version-list: '8.1, 8.2, 8.3, 8.4, 8.5'
@@ -48,11 +48,19 @@ jobs:
           persist-credentials: false
 
       - name: Build extension
-        uses: php/php-windows-builder/extension@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 # 1.8.1
+        uses: php/php-windows-builder/extension@29352c0ef9e8ce65264ea9e287881a6f7758a953 # 1.9.0
         with:
           php-version: ${{ matrix.php-version }}
           ts: ${{ matrix.ts }}
           arch: ${{ matrix.arch }}
+          # extension-matrix flags one lane per (os, VS toolset) pair as
+          # the VS-cache saver, and the action's input defaults to true,
+          # so forwarding it is what stops all 20 lanes writing the same
+          # cache. Our lanes span two toolsets on windows-2022 (vs16 for
+          # 8.1-8.3, vs17 for 8.4-8.5), giving 2 savers. Inert as long as
+          # the runner ships a toolset in range (14.44 as of run
+          # 30447739686): nothing installs, so nothing caches.
+          save-vs-cache: ${{ matrix.save-vs-cache }}
           # Tests run in our own step below: the action's test step
           # hardcodes TEST_PHP_ARGS to `-n` + fastchart.dll only, so the
           # ~90 gd round-trip phpts skip, and its test-runner-args input
@@ -210,11 +218,14 @@ jobs:
           Add-Content $env:GITHUB_ENV "PDFIO_PREFIX=$prefix"
 
       - name: Build extension with PDF enabled
-        uses: php/php-windows-builder/extension@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 # 1.8.1
+        uses: php/php-windows-builder/extension@29352c0ef9e8ce65264ea9e287881a6f7758a953 # 1.9.0
         with:
           php-version: '8.4'
           ts: nts
           arch: x64
+          # This lane shares (windows-2022, vs17) with an 8.4 matrix lane
+          # that is already the designated saver, so restore only.
+          save-vs-cache: 'false'
           run-tests: 'false'
           args: --enable-fastchart --enable-fastchart-dev --with-pdfio
           libs: freetype,libpng,libjpeg-turbo,libwebp
@@ -291,7 +302,7 @@ jobs:
           persist-credentials: false
 
       - name: Upload release artifacts
-        uses: php/php-windows-builder/release@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 # 1.8.1
+        uses: php/php-windows-builder/release@29352c0ef9e8ce65264ea9e287881a6f7758a953 # 1.9.0
         with:
           release: ${{ github.event.release.tag_name }}
         env:


### PR DESCRIPTION
Upstream released 1.9.0 on 2026-07-27. Most of it doesn't reach this repo: 42 of the 71 changed files sit under `php/`, the PHP-source-builder action we don't use, and the `release/` action is byte-identical to 1.8.1.

What actually lands here:

- php-sdk 2.6.0 to 2.8.1, across all 20 build lanes.
- Dependency archives now download to a temp path and get removed in a `finally`, instead of unpacking a zip named after the library into the build directory.
- `extension-matrix` emits a per-lane `save-vs-cache` flag, true for one lane per (os, VS toolset) pair.

That last flag does nothing unless we forward it, since the action's input defaults to `true`. Our matrix covers two toolsets on windows-2022 (vs16 for 8.1-8.3, vs17 for 8.4-8.5), so wiring it gives 2 savers and 18 restore-only lanes. The PDF lane isn't matrix-driven and shares windows-2022/vs17 with an 8.4 matrix lane, so it's pinned to `false`.

Run 30447739686 confirms the flag reaches the lanes correctly: `8.1 x64 nts` and `8.4 x64 nts` get `true`, the other 18 get `false`. It is inert in practice right now, because windows-2022 already ships MSVC 14.44.35207 and both vs16 and vs17 resolve to it, so no lane installs a toolset and no lane caches one. The wiring earns its keep when a runner image stops shipping a toolset in range, or when 8.6 brings windows-2025-vs2026 into the matrix. Today's measurable gains are the php-sdk bump and the dependency-archive cleanup.

That same 14.44 reading clears the one behavioral risk I saw in the diff: 1.9.0 caps vs17 at `minorMax: 49` where 1.8.1 left it open, and the runner sits inside the new bound.

Checked before pushing: zizmor 1.28.0 under the pedantic persona reports no findings, and every input this workflow passes still exists in the 1.9.0 action definitions. CI exercises all 20 build lanes plus the PDF lane end to end, each running the full phpt suite. The release-upload path can't run from a pull request, but that action carries no delta between the two tags.
